### PR TITLE
翻訳元言語を自動検出する機能を追加

### DIFF
--- a/autoload/microsoft/api.vim
+++ b/autoload/microsoft/api.vim
@@ -26,3 +26,19 @@ function! microsoft#api#parse_response(response)
     let xml = vital#of('microsoft_translate').import('Web.XML')
     return xml.parse(a:response.content)['child'][0]
 endfunction
+
+function! microsoft#api#detect(text)
+    let token = microsoft#oauth#access_token()
+
+    let detect_url = 'http://api.microsofttranslator.com/V2/Http.svc/Detect'
+    let detect_get_parameters = {
+    \  'text': a:text,
+    \}
+
+    let detect_get_headers = {
+    \  'Authorization': 'Bearer '. token,
+    \}
+
+    let http = vital#of('microsoft_translate').import('Web.HTTP')
+    return http.get(detect_url, detect_get_parameters, detect_get_headers)
+endfunction

--- a/autoload/microsoft/api.vim
+++ b/autoload/microsoft/api.vim
@@ -7,11 +7,21 @@ function! microsoft#api#translator(from, to, text)
     let token = microsoft#oauth#access_token()
 
     let trans_url = 'http://api.microsofttranslator.com/v2/Http.svc/Translate'
-    let from = a:from ==# 'auto' ? '' : a:from
+
+    let from = a:from
+    let to = a:to
+
+    if a:from ==# 'auto'
+        let response = microsoft#api#detect(a:text)
+        let from = microsoft#api#parse_response(response)
+
+        let to = translate#options#detect_to_lang(from)
+    endif
+
     let trans_get_parameters = {
     \  'text': a:text,
     \  'from': from,
-    \  'to': a:to,
+    \  'to': to,
     \}
 
     let trans_get_headers = {
@@ -20,11 +30,6 @@ function! microsoft#api#translator(from, to, text)
 
     let http = vital#of('microsoft_translate').import('Web.HTTP')
     return http.get(trans_url, trans_get_parameters, trans_get_headers)
-endfunction
-
-function! microsoft#api#parse_response(response)
-    let xml = vital#of('microsoft_translate').import('Web.XML')
-    return xml.parse(a:response.content)['child'][0]
 endfunction
 
 function! microsoft#api#detect(text)
@@ -41,4 +46,9 @@ function! microsoft#api#detect(text)
 
     let http = vital#of('microsoft_translate').import('Web.HTTP')
     return http.get(detect_url, detect_get_parameters, detect_get_headers)
+endfunction
+
+function! microsoft#api#parse_response(response)
+    let xml = vital#of('microsoft_translate').import('Web.XML')
+    return xml.parse(a:response.content)['child'][0]
 endfunction

--- a/autoload/microsoft/api.vim
+++ b/autoload/microsoft/api.vim
@@ -16,6 +16,7 @@ function! microsoft#api#translator(from, to, text)
         let from = microsoft#api#parse_response(response)
 
         let to = translate#options#detect_to_lang(from)
+        call translate#interface#force_to_window_refresh(to)
     endif
 
     let trans_get_parameters = {

--- a/autoload/translate/controller.vim
+++ b/autoload/translate/controller.vim
@@ -5,6 +5,13 @@ function! translate#controller#init_variables()
     if !exists('g:translate_from_lang')
         let g:translate_from_lang = 'auto'
     endif
+    if !exists('g:translate_lang_relation')
+        let g:translate_lang_relation = {
+        \  'en': 'ja',
+        \  'ja': 'en',
+        \  'etc': 'ja',
+        \}
+    endif
 endfunction
 
 function! translate#controller#set_lang(from, to)

--- a/autoload/translate/interface.vim
+++ b/autoload/translate/interface.vim
@@ -60,6 +60,19 @@ function! translate#interface#window_refresh()
     endfor
 endfunction
 
+function! translate#interface#force_to_window_refresh(to)
+    for b in range(1, bufnr('$'))
+        let wintype = getwinvar(bufwinnr(b), 'window_type', {})
+        if wintype ==# {} || !has_key(wintype, 'type')
+            continue
+        endif
+        if wintype['name'] ==# 'translate_to'
+            execute bufwinnr(b) . 'wincmd w'
+            execute 'silent file To\ Language:\ ' . a:to
+        endif
+    endfor
+endfunction
+
 function! translate#interface#window_close()
     for b in range(1, bufnr('$'))
         let wintype = getwinvar(bufwinnr(b), 'window_type', {})

--- a/autoload/translate/options.vim
+++ b/autoload/translate/options.vim
@@ -1,0 +1,8 @@
+function! translate#options#detect_to_lang(from)
+    for key in keys(g:translate_lang_relation)
+        if a:from ==# key
+            return g:translate_lang_relation[key]
+        endif
+    endfor
+    return g:translate_lang_relation['etc']
+endfunction


### PR DESCRIPTION
- 翻訳元言語オプションに'auto'が指定されていた時
- Detect method APIを使ってテキストの言語を検出
- g:translate_lang_relationオプションで検出した言語に一致する翻訳先言語を取得
- 翻訳先言語が取得できなければ'etc'キーの言語を適用
- 翻訳先ウィンドウのバッファ名を変更（From lang: auto -> To lang: *\* となり、g:translate_to_langオプションは変更しない）
- 自動取得した翻訳元言語、一致する翻訳先言語で翻訳を実行（既存ロジック）
